### PR TITLE
Fix typo in arrow function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Arrow function does not work with AoT when it is passed to an `NgModule`.
 
 Don't:
 ```ts
-export const couterReducer = (state, action: Action) => {
+export const counterReducer = (state, action: Action) => {
   // ...
 }
 ```


### PR DESCRIPTION
I know, it's silly. I just noticed, so figured I'd fix it.